### PR TITLE
lower level fix for offnetwork reservoir initial conditions

### DIFF
--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -832,14 +832,6 @@ def compute_nhd_routing_v02(
                     qlat_sub = qlat_sub.reindex(param_df_sub.index)
                     q0_sub = q0_sub.reindex(param_df_sub.index)
 
-
-                    if not waterbodies_df.empty:
-                        #To handle edge case when the offnetwork upstream is a reservoir
-                        q0_sub.loc[lake_segs,"qu0"] = waterbodies_df.loc[lake_segs,"qd0"]
-                        q0_sub.loc[lake_segs,"qd0"] = waterbodies_df.loc[lake_segs,"qd0"]
-                        q0_sub.loc[lake_segs,"h0"] = waterbodies_df.loc[lake_segs,"h0"]
-
-
                     print ("jobs.append")
                     print(compute_func_switch)
                     us: fvd

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -1194,8 +1194,12 @@ cpdef object compute_network_structured(
         fill_index_mask[fill_index] = False
         for idx, val in enumerate(tmp["results"]):
             flowveldepth_nd[fill_index, (idx//qvd_ts_w) + 1, idx%qvd_ts_w] = val
-            flowveldepth_nd[fill_index, 0, 0] = init_array[fill_index, 0] # initial flow condition
-            flowveldepth_nd[fill_index, 0, 2] = init_array[fill_index, 2] # initial depth condition
+            if data_idx[fill_index]  in lake_numbers_col:
+                res_idx = binary_find(lake_numbers_col, [data_idx[fill_index]])
+                flowveldepth_nd[fill_index, 0, 0] = wbody_parameters[res_idx, 9] # TODO ref dataframe column label
+            else:
+                flowveldepth_nd[fill_index, 0, 0] = init_array[fill_index, 0] # initial flow condition
+                flowveldepth_nd[fill_index, 0, 2] = init_array[fill_index, 2] # initial depth condition
 
     #Init buffers
     lateral_flows = np.zeros( max_buff_size, dtype='float32' )


### PR DESCRIPTION
Here is a less hacky fix for initializing reservoir states. Recall, that without this fix, we get NaNs downstream of reservoirs when the compute kernel is set to `compute_network_structured`. I am issuing the PR on this branch because the reservoir subnetwork creation forces reservoir nodes to be the offnetwork upstreams of downstream stream sub-networks. 